### PR TITLE
Merging extended I2C library into master

### DIFF
--- a/firmware/lib/L0_LowLevel/source/startup.cpp
+++ b/firmware/lib/L0_LowLevel/source/startup.cpp
@@ -128,63 +128,61 @@ extern void (* const g_pfnVectors[])(void);
 __attribute__ ((section(".isr_vector")))
 void (* const g_pfnVectors[])(void) =
 {
-        // Core Level - CM3
-        &_vStackTop,        // The initial stack pointer
-        isr_reset,          // The reset handler
-        isr_nmi,            // The NMI handler
-        isr_hard_fault,     // The hard fault handler
-        isr_mem_fault,      // The MPU fault handler
-        isr_bus_fault,      // The bus fault handler
-        isr_usage_fault,    // The usage fault handler
-        0,                  // Reserved
-        0,                  // Reserved
-        0,                  // Reserved
-        0,                  // Reserved
-        vPortSVCHandler,    // FreeRTOS SVC-call handler (naked function so needs direct call - not a wrapper)
-        isr_debug_mon,      // Debug monitor handler
-        0,                  // Reserved
-        xPortPendSVHandler, // FreeRTOS PendSV handler (naked function so needs direct call - not a wrapper)
-        isr_sys_tick,       // FreeRTOS SysTick handler (we enclose inside a wrapper to track OS overhead)
+    // Core Level - CM3
+    &_vStackTop,        // The initial stack pointer
+    isr_reset,          // The reset handler
+    isr_nmi,            // The NMI handler
+    isr_hard_fault,     // The hard fault handler
+    isr_mem_fault,      // The MPU fault handler
+    isr_bus_fault,      // The bus fault handler
+    isr_usage_fault,    // The usage fault handler
+    0,                  // Reserved
+    0,                  // Reserved
+    0,                  // Reserved
+    0,                  // Reserved
+    vPortSVCHandler,    // FreeRTOS SVC-call handler (naked function so needs direct call - not a wrapper)
+    isr_debug_mon,      // Debug monitor handler
+    0,                  // Reserved
+    xPortPendSVHandler, // FreeRTOS PendSV handler (naked function so needs direct call - not a wrapper)
+    isr_sys_tick,       // FreeRTOS SysTick handler (we enclose inside a wrapper to track OS overhead)
 
-        // Chip Level - LPC17xx - common ISR that will call the real ISR
-        isr_forwarder_routine,      // 16, 0x40 - WDT
-        isr_forwarder_routine,      // 17, 0x44 - TIMER0
-        isr_forwarder_routine,      // 18, 0x48 - TIMER1
-        isr_forwarder_routine,      // 19, 0x4c - TIMER2
-        isr_forwarder_routine,      // 20, 0x50 - TIMER3
-        isr_forwarder_routine,      // 21, 0x54 - UART0
-        isr_forwarder_routine,      // 22, 0x58 - UART1
-        isr_forwarder_routine,      // 23, 0x5c - UART2
-        isr_forwarder_routine,      // 24, 0x60 - UART3
-        isr_forwarder_routine,      // 25, 0x64 - PWM1
-        isr_forwarder_routine,      // 26, 0x68 - I2C0
-        isr_forwarder_routine,      // 27, 0x6c - I2C1
-        isr_forwarder_routine,      // 28, 0x70 - I2C2
-        isr_forwarder_routine,      // 29, 0x74 - SPI
-        isr_forwarder_routine,      // 30, 0x78 - SSP0
-        isr_forwarder_routine,      // 31, 0x7c - SSP1
-        isr_forwarder_routine,      // 32, 0x80 - PLL0 (Main PLL)
-        isr_forwarder_routine,      // 33, 0x84 - RTC
-        isr_forwarder_routine,      // 34, 0x88 - EINT0
-        isr_forwarder_routine,      // 35, 0x8c - EINT1
-        isr_forwarder_routine,      // 36, 0x90 - EINT2
-        isr_forwarder_routine,      // 37, 0x94 - EINT3
-        isr_forwarder_routine,      // 38, 0x98 - ADC
-        isr_forwarder_routine,      // 39, 0x9c - BOD
-        isr_forwarder_routine,      // 40, 0xA0 - USB
-        isr_forwarder_routine,      // 41, 0xa4 - CAN
-        isr_forwarder_routine,      // 42, 0xa8 - GP DMA
-        isr_forwarder_routine,      // 43, 0xac - I2S
-        isr_forwarder_routine,      // 44, 0xb0 - Ethernet
-        isr_forwarder_routine,      // 45, 0xb4 - RITINT
-        isr_forwarder_routine,      // 46, 0xb8 - Motor Control PWM
-        isr_forwarder_routine,      // 47, 0xbc - Quadrature Encoder
-        isr_forwarder_routine,      // 48, 0xc0 - PLL1 (USB PLL)
-        isr_forwarder_routine,      // 49, 0xc4 - USB Activity interrupt to wakeup
-        isr_forwarder_routine,      // 50, 0xc8 - CAN Activity interrupt to wakeup
-    };
-
-
+    // Chip Level - LPC17xx - common ISR that will call the real ISR
+    isr_forwarder_routine,      // 16, 0x40 - WDT
+    isr_forwarder_routine,      // 17, 0x44 - TIMER0
+    isr_forwarder_routine,      // 18, 0x48 - TIMER1
+    isr_forwarder_routine,      // 19, 0x4c - TIMER2
+    isr_forwarder_routine,      // 20, 0x50 - TIMER3
+    isr_forwarder_routine,      // 21, 0x54 - UART0
+    isr_forwarder_routine,      // 22, 0x58 - UART1
+    isr_forwarder_routine,      // 23, 0x5c - UART2
+    isr_forwarder_routine,      // 24, 0x60 - UART3
+    isr_forwarder_routine,      // 25, 0x64 - PWM1
+    isr_forwarder_routine,      // 26, 0x68 - I2C0
+    isr_forwarder_routine,      // 27, 0x6c - I2C1
+    isr_forwarder_routine,      // 28, 0x70 - I2C2
+    isr_forwarder_routine,      // 29, 0x74 - SPI
+    isr_forwarder_routine,      // 30, 0x78 - SSP0
+    isr_forwarder_routine,      // 31, 0x7c - SSP1
+    isr_forwarder_routine,      // 32, 0x80 - PLL0 (Main PLL)
+    isr_forwarder_routine,      // 33, 0x84 - RTC
+    isr_forwarder_routine,      // 34, 0x88 - EINT0
+    isr_forwarder_routine,      // 35, 0x8c - EINT1
+    isr_forwarder_routine,      // 36, 0x90 - EINT2
+    isr_forwarder_routine,      // 37, 0x94 - EINT3
+    isr_forwarder_routine,      // 38, 0x98 - ADC
+    isr_forwarder_routine,      // 39, 0x9c - BOD
+    isr_forwarder_routine,      // 40, 0xA0 - USB
+    isr_forwarder_routine,      // 41, 0xa4 - CAN
+    isr_forwarder_routine,      // 42, 0xa8 - GP DMA
+    isr_forwarder_routine,      // 43, 0xac - I2S
+    isr_forwarder_routine,      // 44, 0xb0 - Ethernet
+    isr_forwarder_routine,      // 45, 0xb4 - RITINT
+    isr_forwarder_routine,      // 46, 0xb8 - Motor Control PWM
+    isr_forwarder_routine,      // 47, 0xbc - Quadrature Encoder
+    isr_forwarder_routine,      // 48, 0xc0 - PLL1 (USB PLL)
+    isr_forwarder_routine,      // 49, 0xc4 - USB Activity interrupt to wakeup
+    isr_forwarder_routine,      // 50, 0xc8 - CAN Activity interrupt to wakeup
+};
 
 //*****************************************************************************
 // Functions to carry out the initialization of RW and BSS data sections. These

--- a/firmware/lib/L2_Drivers/base/i2c_base.hpp
+++ b/firmware/lib/L2_Drivers/base/i2c_base.hpp
@@ -91,11 +91,17 @@ class I2C_Base
          */
         bool writeReg(uint8_t deviceAddress, uint8_t registerAddress, uint8_t value);
 
+        bool writeRegisterThenRead(uint8_t address, uint8_t * wdata, uint32_t wlength, uint8_t * rdata, uint32_t rlength);
+
         /// @copydoc transfer()
         bool readRegisters(uint8_t deviceAddress, uint8_t firstReg, uint8_t* pData, uint32_t transferSize);
+        bool readRegisters(uint8_t address, uint8_t * rdata, uint32_t rlength);
 
         /// @copydoc transfer()
         bool writeRegisters(uint8_t deviceAddress, uint8_t firstReg, uint8_t* pData, uint32_t transferSize);
+
+        bool writeRegisters(uint8_t address, uint8_t * wdata, uint32_t wlength);
+
 
         /**
          * This function can be used to check if an I2C device responds to its address,
@@ -111,6 +117,7 @@ class I2C_Base
 
 
     protected:
+        uint8_t writeBuffer[256];
         /**
          * Protected constructor that requires parent class to provide I2C
          * base register address for which to operate this I2C driver
@@ -153,11 +160,12 @@ class I2C_Base
          */
         typedef struct
         {
-            uint32_t trxSize;   ///< # of bytes to transfer.
-            uint8_t slaveAddr;  ///< Slave Device Address
-            uint8_t firstReg;   ///< 1st Register to Read or Write
-            uint8_t error;      ///< Error if any occurred within I2C
-            uint8_t *pMasterData;  ///< Buffer of the I2C Read or Write
+            uint8_t         slaveAddr;      ///< Slave Device Address
+            uint8_t         error;          ///< Error if any occurred within I2C
+            uint8_t         *dataWrite;     ///< Buffer of the I2C Write
+            uint32_t        writeLength;    ///< # of bytes to write
+            uint8_t         *dataRead;      ///< Buffer of the I2C Read
+            uint32_t        readLength;     ///< # of bytes to read
         } mI2CTransaction_t;
 
         /// The I2C Input Output frame that contains I2C transaction information
@@ -171,6 +179,14 @@ class I2C_Base
          *              - Read  is complete
          */
         mStateMachineStatus_t i2cStateMachine();
+        mStateMachineStatus_t state;
+
+        void clearSIFlag();
+        void setSTARTFlag();
+        void clearSTARTFlag();
+        void setAckFlag();
+        void setNackFlag();
+        void setStop();
 
         /**
          * Read/writes multiple bytes to an I2C device starting from the first register
@@ -182,7 +198,8 @@ class I2C_Base
          * @param transferSize      The number of bytes to read/write
          * @returns true if the transfer was successful
          */
-        bool transfer(uint8_t deviceAddress, uint8_t firstReg, uint8_t* pData, uint32_t transferSize);
+        // bool transfer(uint8_t deviceAddress, uint8_t firstReg, uint8_t* pData, uint32_t transferSize);
+        bool transfer(uint8_t address, uint8_t * wdata, uint32_t wlength, uint8_t * rdata, uint32_t rlength);
 
         /**
          * This is the entry point for an I2C transaction
@@ -191,7 +208,8 @@ class I2C_Base
          * @param pBytes    The pointer to one or more data bytes to read or write
          * @param len       The length of the I2C transaction
          */
-        void i2cKickOffTransfer(uint8_t devAddr, uint8_t regStart, uint8_t* pBytes, uint32_t len);
+        // void i2cKickOffTransfer(uint8_t devAddr, uint8_t regStart, uint8_t* pBytes, uint32_t len);
+        void i2cKickOffTransfer(uint8_t addr, uint8_t * wbytes, uint32_t wlength, uint8_t * rbytes, uint32_t rlength);
 };
 
 

--- a/firmware/lib/L2_Drivers/src/eint.c
+++ b/firmware/lib/L2_Drivers/src/eint.c
@@ -45,7 +45,7 @@ static eint3_entry_t *gp_port2_falling_list = NULL;
  * Goes through the linked list to find out which interrupt triggered, and makes the callback
  * @param [in] isr_bits_ptr   The pointer to the variable that contains interrupt status
  * @param [in] int_clr_ptr    The pointer to the register to clear the real interrupt
- * @param [in[ list_head_ptr  The linked list head pointer of the configured interrupts
+ * @param [in] list_head_ptr  The linked list head pointer of the configured interrupts
  *
  * @note isr_bits_ptr are cleared if the callback was made.  If the bits are not cleared then
  *       the interrupt was set, and no callback was found.  This shouldn't happen though :)

--- a/firmware/lib/L4_IO/src/io_source.cpp
+++ b/firmware/lib/L4_IO/src/io_source.cpp
@@ -221,8 +221,6 @@ uint32_t IR_Sensor::getLastIRCode()
     return signal;
 }
 
-
-
 bool LED_Display::init()
 {
     bool devicePresent = checkDeviceResponse();
@@ -263,8 +261,6 @@ void LED_Display::setRightDigit(char alpha)
     mNumAtDisplay[1] = alpha;
     writeReg(outputPort0, LED_DISPLAY_CHARMAP[(unsigned) (alpha & 0x7F) ]);
 }
-
-
 
 
 bool LED::init()


### PR DESCRIPTION
* So far, working version of I2C base with read register without requiring the need to write at the same time with a repeated start. I2C master read, works, i2c write work, previous functionality works, I2C discover works.

* Moving to from int32_t back to uint32_t

* Adding fixed i2c base code for single register transmit and send.

* Arm assembly support (#18)

* Added rules into make file to allow for assembly compilation.
Added in sample Assembly folder to demonstrate making a project in assembly in SJSU-Dev.
Created a declassify c++ file as a space to convert C++ method calls to global functions.

* Updated README

* Macroified the bit setting to make the assembly look cleaner