### PR TITLE
Fix spelling of "Darwin"

### DIFF
--- a/setup
+++ b/setup
@@ -82,7 +82,7 @@ case "$OS" in
 		;;
 
 	Darwin) # OS X Case
-		echo "Operating System: Mac OSX Darvin"
+		echo "Operating System: Mac OSX Darwin"
 		SJSUONEDEV=/dev/tty.usbserial-A503JOLS
 		# ========= Xcode ========== #
 		# xcode-select --install &> /dev/null	# Install Command Line tools (make etc...)


### PR DESCRIPTION
Changed from "Darvin" to "Darwin"