### PR TITLE
Fixing MacOSX and overal python issues

### DIFF
--- a/makefile
+++ b/makefile
@@ -280,7 +280,7 @@ $(OBJ_DIR)/%.o: $(LIB_DIR)/%.c
 	@echo ' '
 
 $(DBC_BUILD):
-	python "$(LIB_DBC_DIR)/dbc_parse.py" -i "$(LIB_DBC_DIR)/243.dbc" -s $(ENTITY) > $(DBC_BUILD)
+	python2.7 "$(LIB_DBC_DIR)/dbc_parse.py" -i "$(LIB_DBC_DIR)/243.dbc" -s $(ENTITY) > $(DBC_BUILD)
 
 $(DBC_DIR):
 	mkdir -p $(DBC_DIR)
@@ -299,14 +299,14 @@ clean:
 sym-flash: sym-build
 	@bash -c "\
 	source $(SJBASE)/tools/Hyperload/modules/bin/activate && \
-	python $(SJBASE)/tools/Hyperload/hyperload.py $(SJDEV) $(SYMBOLS_HEX)"
+	python2.7 $(SJBASE)/tools/Hyperload/hyperload.py $(SJDEV) $(SYMBOLS_HEX)"
 
 flash: build
 	@bash -c "\
 	source $(SJBASE)/tools/Hyperload/modules/bin/activate && \
-	python $(SJBASE)/tools/Hyperload/hyperload.py $(SJDEV) $(HEX)"
+	python2.7 $(SJBASE)/tools/Hyperload/hyperload.py $(SJDEV) $(HEX)"
 
 telemetry:
 	@bash -c "\
 	source $(SJBASE)/tools/Telemetry/modules/bin/activate && \
-	python $(SJBASE)/tools/Telemetry/telemetry.py"
+	python2.7 $(SJBASE)/tools/Telemetry/telemetry.py"

--- a/setup
+++ b/setup
@@ -84,13 +84,15 @@ case "$OS" in
 	Darwin) # OS X Case
 		echo "Operating System: Mac OSX Darvin"
 		SJSUONEDEV=/dev/tty.usbserial-A503JOLS
-		# ========= Xcode ========== #
-		# xcode-select --install &> /dev/null	# Install Command Line tools (make etc...)
-		# sudo xcodebuild -license # Accept User Agreement
-		echo " ───────────────────────────────────────────────────┐"
-		echo "           Using EASY_INSTALL to install PIP         "
-		echo "└─────────────────────────────────────────────────── "
-		sudo easy_install pip
+        echo " ───────────────────────────────────────────────────┐"
+        echo "    Install XCode Command Line Tools (GCC, make)     "
+        echo "└─────────────────────────────────────────────────── "
+        xcode-select --install &> /dev/null	# Install Command Line tools (make etc...)
+        sudo xcodebuild -license accept # Accept User Agreement
+        echo " ───────────────────────────────────────────────────┐"
+        echo "        Installing PIP via bootstrap.pypa.io         "
+        echo "└─────────────────────────────────────────────────── "
+        curl https://bootstrap.pypa.io/get-pip.py | python2.7
 		echo " ──────────────────────────────────────────────────┐"
 		echo "           Downloading gcc-arm-embedded             "
 		echo "└────────────────────────────────────────────────── "


### PR DESCRIPTION
- Moving all calls to python -> python2.7
- Added back in xcode-install
- Using pypa.io and curl to install pip