### PR TITLE
Fixing MacOSX and overal python issues

### DIFF
--- a/setup
+++ b/setup
@@ -118,11 +118,11 @@ cd $BASE
 echo " ───────────────────────────────────────────────────┐"
 echo "                   Upgrading PIP                     "
 echo "└─────────────────────────────────────────────────── "
-sudo -H pip install --upgrade pip
+sudo -H pip2.7 install --upgrade pip
 echo " ───────────────────────────────────────────────────┐"
 echo "            Upgrading Python's Virtualenv            "
 echo "└─────────────────────────────────────────────────── "
-sudo -H pip install --upgrade virtualenv
+sudo -H pip2.7 install --upgrade virtualenv
 echo " ───────────────────────────────────────────────────┐"
 echo "                Setting Up Hyperload                 "
 echo "└─────────────────────────────────────────────────── "


### PR DESCRIPTION
- Moving all calls to python -> python2.7
- Added back in xcode-install
- Using pypa.io and curl to install pip
- changed from pip -> pip2.7 to ensure that python2.7 is used